### PR TITLE
Added example google-services.json to speed up importing project

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,3 @@
 /build
+/google-services.json
 /fabric.properties

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,3 +1,2 @@
 /build
-/google-services.json
 /fabric.properties

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,64 @@
+{
+  "project_info": {
+    "project_id": "this-is-a-sample",
+    "project_number": "999999999999",
+    "name": "AdMob Samples",
+    "firebase_url": "https://this-is-a-sample-do-not-use.firebaseio.com",
+    "storage_bucket": "this-is-a-sample-do-not-use.storage.firebase.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:999999999999:android:0000000000000000",
+        "client_id": "org.bookdash.android",
+        "client_type": 1,
+        "android_client_info": {
+          "package_name": "org.bookdash.android",
+          "certificate_hash": []
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "this-is-a-sample-do-not-use.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.google.android.gms.example.interstitialexample",
+            "certificate_hash": "0000000000000000000000000000000000000000"
+          }
+        },
+        {
+          "client_id": "this-is-a-sample-do-not-use.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "000000000000000000000000000000000000000"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "cloud_messaging_service": {
+          "status": 2,
+          "apns_config": []
+        },
+        "appinvite_service": {
+          "status": 2,
+          "other_platform_oauth_client": []
+        },
+        "google_signin_service": {
+          "status": 2
+        },
+        "ads_service": {
+          "status": 2,
+          "test_banner_ad_unit_id": "ca-app-pub-3940256099942544/6300978111",
+          "test_interstitial_ad_unit_id": "ca-app-pub-3940256099942544/1033173712"
+        }
+      }
+    }
+  ],
+  "client_info": [],
+  "ARTIFACT_VERSION": "1"
+}


### PR DESCRIPTION
I found it annoying that Android Studio couldn't import project because of missing `google-services.json` file. I know it's set to be ignored by git on purpose, but I would like to propose adding mocked version of this file just for the sake of simplicity for all of potential developers who would like to contribute.

`google-service.json` was forked from [Google ads example project](https://github.com/googleads/googleads-mobile-android-examples/blob/master/admob/InterstitialExample/app/google-services.json)