### PR TITLE
2.9.2 Security Patch targetSdkVersion -> 33

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,18 +30,21 @@
         <activity
             android:name=".presentation.main.MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="false">
         </activity>
         <activity
             android:name=".presentation.readbook.BookDetailActivity"
             android:label="@string/app_name"
             android:screenOrientation="sensorLandscape"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar.FullScreen">
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar.FullScreen"
+            android:exported="false">
         </activity>
         <activity
             android:name=".presentation.bookinfo.BookInfoActivity"
             android:label=""
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".presentation.main.MainActivity"/>
@@ -61,7 +64,8 @@
         <activity
             android:name=".presentation.splash.SplashActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
@@ -71,7 +75,8 @@
         <activity
             android:name=".presentation.search.SearchActivity"
             android:label="@string/screen_title_search"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="false">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".presentation.main.MainActivity"/>
@@ -79,7 +84,8 @@
         <activity
             android:name="za.co.riggaroo.materialhelptutorial.tutorial.MaterialTutorialActivity"
             android:label="@string/tutorial_screen"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="false">
         </activity>
 
         <meta-data

--- a/app/src/main/java/org/bookdash/android/data/book/DownloadServiceImpl.java
+++ b/app/src/main/java/org/bookdash/android/data/book/DownloadServiceImpl.java
@@ -100,11 +100,11 @@ public class DownloadServiceImpl implements DownloadService {
                 Log.e(TAG, "EX: ", e);
             }
 
-            FirebaseCrashlytics.getInstance().log("File path: " + fileName);
+            FirebaseCrashlytics.getInstance().log("File path: " + fileName); // TODO Remove in next release if book downloading bug is fixed.
             FirebaseCrashlytics.getInstance().recordException(e);
             Log.e(TAG, "Ex:" + e.getMessage(), e);
         } catch (Exception e) {
-            FirebaseCrashlytics.getInstance().log("File path: " + fileName);
+            FirebaseCrashlytics.getInstance().log("File path: " + fileName); // TODO Remove in next release if book downloading bug is fixed.
             FirebaseCrashlytics.getInstance().recordException(e);
             Log.e(TAG, "error parsing book: " + fileName, e);
         }

--- a/app/src/main/java/org/bookdash/android/domain/model/firebase/FireBookDetails.java
+++ b/app/src/main/java/org/bookdash/android/domain/model/firebase/FireBookDetails.java
@@ -137,7 +137,18 @@ public class FireBookDetails implements Parcelable {
             if (files == null || files.length == 0 || files[0] == null) {
                 return null;
             }
-            return files[0].getAbsoluteFile().toString();
+            for (File aFile : files) {
+                if (!aFile.getAbsoluteFile().toString().contains("MACOSX")) {
+                    // This is a workaround bugfix (no other solution possible). Previously the app
+                    // assumed that a book's root folder only contains one folder (containing the
+                    // book images and .json file). However, in the CMS content conversion process
+                    // where PDF books are converted into .json and images so that the app can
+                    // consume it, mac inserted a "__MACOSX" folder in certain cases. This causes
+                    // this method to return the MACOSX folder as the book folder on certain devices
+                    // as file.listFiles() does not guarantee any specific ordering.
+                    return aFile.getAbsoluteFile().toString();
+                }
+            }
         }
         return null;
     }

--- a/app/src/main/java/org/bookdash/android/presentation/bookinfo/BookInfoActivity.java
+++ b/app/src/main/java/org/bookdash/android/presentation/bookinfo/BookInfoActivity.java
@@ -1,6 +1,7 @@
 package org.bookdash.android.presentation.bookinfo;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
@@ -470,11 +471,15 @@ public class BookInfoActivity extends BaseAppCompatActivity implements BookInfoC
 
     @Override
     public void sendShareEvent(String bookTitle) {
-        Intent sendIntent = new Intent();
-        sendIntent.setAction(Intent.ACTION_SEND);
-        sendIntent.putExtra(Intent.EXTRA_TEXT, getString(R.string.sharing_book_title, bookTitle));
-        sendIntent.setType("text/plain");
-        startActivity(sendIntent);
+        try {
+            Intent sendIntent = new Intent();
+            sendIntent.setAction(Intent.ACTION_SEND);
+            sendIntent.putExtra(Intent.EXTRA_TEXT, getString(R.string.sharing_book_title, bookTitle));
+            sendIntent.setType("text/plain");
+            startActivity(sendIntent);
+        } catch (ActivityNotFoundException anfe) {
+            showSnackBarMessage(R.string.share_book_error_no_apps_found);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/bookdash/android/presentation/bookinfo/BookInfoPresenter.java
+++ b/app/src/main/java/org/bookdash/android/presentation/bookinfo/BookInfoPresenter.java
@@ -103,7 +103,7 @@ class BookInfoPresenter extends BasePresenter<BookInfoContract.View> implements 
                             BookPages bookPages = downloadProgressItem.getBookPages();
                             if (bookPages == null) {
                                 getView().showSnackBarMessage(R.string.failed_to_open_book);
-                                FirebaseCrashlytics.getInstance().recordException(new Exception("Book pages null after completed download."));
+                                FirebaseCrashlytics.getInstance().recordException(new Exception("Book pages null after completed download.")); // TODO Remove in next release if book downloading bug is fixed.
                                 analytics.trackDownloadBookFailed(bookInfo, "failed_to_open_book");
                                 return;
                             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="sharing_book_title">I have just read \"%s\". Download Book Dash now and read it for free! http://play.google.com/store/apps/details?id=org.bookdash.android</string>
     <string name="invitation_title">Download Book Dash</string>
     <string name="invite_error_no_apps_found">Unfortunately no apps were found to invite your friends with.</string>
+    <string name="share_book_error_no_apps_found">Unfortunately no apps were found that can share this book with your friends.</string>
     <string name="invite_using">Choose an app to invite with</string>
     <string name="invitation_subject">Install the Book Dash app for free books</string>
     <string name="invitation_message">I think you\'ll love the Book Dash app for free children\'s books.\n\nYou can get it here:\nhttps://play.google.com/store/apps/details?id=org.bookdash.android</string>

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ allprojects {
 }
 
 ext {
-    versionCode = 35
-    versionName = "2.9.0"
+    versionCode = 36
+    versionName = "2.9.1"
     minSdkVersion = 16
     compileSdkVersion = 29
     junitVersion = '4.13.1'

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,10 @@ allprojects {
 }
 
 ext {
-    versionCode = 36
-    versionName = "2.9.1"
+    versionCode = 37
+    versionName = "2.9.2"
     minSdkVersion = 16
-    compileSdkVersion = 29
+    compileSdkVersion = 33
     junitVersion = '4.13.1'
     mockitoVersion = '1.10.19'
     powerMockito = '1.7.4'


### PR DESCRIPTION
Starting in November 2022, app updates must target API level 31 or above and adjust for behavioral changes in Android 12; except for Wear OS apps, which must target API level 30 or higher.

https://developer.android.com/google/play/requirements/target-sdk